### PR TITLE
chore: add gitignore for local maintenance files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+CLAUDE.md
+ROADMAP.md
+data/


### PR DESCRIPTION
## Summary
- Added `.gitignore` to keep local maintenance files (CLAUDE.md, ROADMAP.md, data/) out of the public repo
- Only `README.md` and `.gitignore` are publicly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)