### PR TITLE
docs: full HR entry separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Specialist fine-tuning that bakes tool definitions into model weights via LoRA r
 - **[Edge MCP Caller](https://github.com/adityonugrohoid/edge-mcp-caller):** 418/420 eval accuracy, 14,033 training examples, 14 tools across 2 MCP servers, trained on single RTX 4060 (8GB VRAM), no accuracy degradation scaling from 3 to 14 tools
 - **[NIM Explorer](https://github.com/adityonugrohoid/nim-explorer):** Machine-readable catalog of 107 Nvidia NIM models with automated capability probing (tool calling, JSON mode, thinking) via live endpoint testing
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [K8s FinOps Explore](https://github.com/search?q=user%3Aadityonugrohoid+gpu-autoscale-inference+OR+vllm-explorer&type=repositories)
 **Scale-to-Zero GPU Inference on GKE**
@@ -28,7 +28,7 @@ Production GPU inference platform that costs $0 when idle. Two-layer autoscaling
 - **[GPU Autoscale Inference](https://github.com/adityonugrohoid/gpu-autoscale-inference):** vLLM with continuous batching, TTFT p95 ~140-200ms warm, 12-panel Grafana dashboard (Prometheus + NVIDIA DCGM), Locust load testing, $0 cost when idle
 - **[vLLM Explorer](https://github.com/adityonugrohoid/vllm-explorer):** Systematic API surface probing that drove model selection (Qwen2.5-1.5B) and parameter tuning via TTFT + tokens/sec benchmarks
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [AgentLens - Agentic RAG Portfolio](https://agentlens.adityonugroho.com/) LIVE
 **Multi-Agent RAG Built From First Principles**
@@ -54,7 +54,7 @@ Fine-tuned a 1.2B model to achieve +325% improvement on spatial coordinate tasks
 - **[Spatial LLM](https://github.com/adityonugrohoid/spatial-llm):** QLoRA r=32 on 4-bit NF4, 520 examples, 30 epochs, train loss 0.005 (99.84% accuracy), full pipeline from training to GGUF conversion to Ollama registration, 731 MB model
 - **[Voxel Architect](https://github.com/adityonugrohoid/voxel-architect):** Agentic voxel builder where an LLM constructs 3D structures in a 16x16x16 grid using tool calling, with model selection and parsing strategies backed by data from 1,792 research runs across 32 models
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [Open Layer Standard](https://github.com/search?q=user%3Aadityonugrohoid+open-layer+OR+ollama-tool-calling-research+OR+ollama-catalog&type=repositories)
 **LLM Inference I/O Standardization + Tool Calling Research**
@@ -65,7 +65,7 @@ Spec-first approach to LLM provider normalization with conformance tests proving
 - **[Ollama Tool Calling Research](https://github.com/adityonugrohoid/ollama-tool-calling-research):** 60 scored checks per model across 4 flag combinations; 10/32 achieve perfect scores; ministral-3:3b (3B) matches 1T+ models; key finding: streaming degrades tool calling and never improves it
 - **[Ollama Catalog](https://github.com/adityonugrohoid/ollama-catalog):** 392 models from 3 sources (Cloud API, OCI Registry, Local) with capability detection (tools, vision, thinking) from template blob patterns, zero model weight downloads
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [pAIjo RAG](https://github.com/adityonugrohoid/pAIjo-rag)
 **Islamic Knowledge Retrieval for the Indonesian Muslim Community**
@@ -74,7 +74,7 @@ Retrieval backbone for pAIjo, a WhatsApp/Telegram-based Islamic knowledge assist
 
 - 68 indexed knowledge points across 4 categories (NU traditions, Ramadan, fiqih, fatwa), sub-100ms retrieval, dual embedding backend (local MiniLM 384-dim vs. OpenAI 1536-dim)
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [RAG Systems & Local LLM Infrastructure](https://github.com/search?q=user%3Aadityonugrohoid+enterprise-rag-platform+OR+rag-operator-console+OR+ollama-multi-llm-server+OR+ollama-runtime&type=repositories)
 **Enterprise RAG + Phased Local LLM Stack**
@@ -101,7 +101,7 @@ Three-component AI system for reducing MTTR in NOC workflows, each mapping to on
 - **[NOC-Oracle](https://github.com/adityonugrohoid/noc-oracle):** RAG with hybrid search (vector + regex keyword boosting) for exact error code matching, hallucination trap toggle showing ungrounded vs. RAG-verified answers
 - **[Net-Ops Agent](https://github.com/adityonugrohoid/net-ops-agent):** Reasoning-action separation with human-in-the-loop approval gate, deterministic function calling from pre-defined toolbelt
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [Telecom ML](https://github.com/search?q=user%3Aadityonugrohoid+telecom-ml+OR+telecom-churn+OR+telecom-root-cause+OR+telecom-anomaly+OR+telecom-capacity+OR+telecom-network-optimization&type=repositories)
 **6 End-to-End ML Use Cases + Framework**
@@ -119,7 +119,7 @@ Six independent implementations with domain-informed synthetic data generators e
 
 - **[Telecom ML Framework](https://github.com/adityonugrohoid/telecom-ml-framework):** 6 production-ready project templates with domain-informed data generator patterns, temporal leakage prevention, and unified standards
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [Telecom Digital Twin + MLOps](https://github.com/search?q=user%3Aadityonugrohoid+telecom-digital-twin+OR+telecom-qoe-analytics&type=repositories)
 **Synthetic Generation -> Model Training -> Strategic Insights**
@@ -139,19 +139,19 @@ Deterministic multi-table generator (50K users, 2K cells, ~5.6M sessions) with c
 
 - 3-step interior design render pipeline (text -> sketch -> render) deployed on **[Cloud Run](https://google-cloud-ai-studio-1099058340933.us-central1.run.app)** (Streamlit + Vertex AI) and **[Vercel](https://adityolab-ai-studio.vercel.app/)** (Next.js 14), comparing gemini-2.5-flash-image vs gemini-3-pro-image-preview for sketch-to-render fidelity
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [Observability & Agent Frameworks](https://github.com/adityonugrohoid/openclaw-dashboard)
 
 - OpenClaw Dashboard: zero-build SPA (FastAPI + Tailwind CDN + Alpine.js) with 7 views covering agent sessions, configuration, security audit, and system resources, purpose-built with intelligent data filtering and glassmorphism UI
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [Trading & Fintech](https://github.com/search?q=user%3Aadityonugrohoid+polymarket-agent+OR+trailing-edge+OR+ratu+OR+binance-colo-research&type=repositories)
 
 - 7 repos: autonomous LLM trading agent with 3-model council and 55 tests, async Binance bot with Ed25519 auth and systemd deployment, FIX 4.4 market making (3 sessions), REST analytics (7 endpoints), on-chain whale tracking (6 chains), DEX pair scanning (4 chains), co-location latency research (4.4x improvement from Tokyo VPS)
 
-<p align="center">────────────────────────────────────────</p>
+---
 
 ### [VPS Deploy Playbook](https://github.com/adityonugrohoid/vps-deploy-playbook)
 


### PR DESCRIPTION
## Summary
- Replaced `<p align="center">────────────────────────────────────────</p>` with `---` for all 10 within-tier entry separators
- `---` is the thinnest full-width horizontal rule available in GitHub markdown (CSS/HTML attributes for thickness are stripped by GitHub's sanitizer)
- Tier hierarchy preserved: tier boundaries have `---` + `&nbsp;` + badge block, entries have just `---`

🤖 Generated with [Claude Code](https://claude.com/claude-code)